### PR TITLE
Add optional limit to number opens per site

### DIFF
--- a/background.js
+++ b/background.js
@@ -61,6 +61,17 @@ async function handleTab(tabId, url) {
         chrome.storage.sync.set({'lastunlock': 0});
         unlockTime = 0;
     }
+
+    let midnight = new Date(options.lastUnlock * 1000);
+    midnight.setDate(midnight.getDate() + 1);
+    midnight.setHours(0);
+    midnight.setMinutes(0);
+    midnight.setSeconds(0);
+    midnight.setMilliseconds(0);
+    if (new Date(now * 1000) >= midnight) {
+        chrome.storage.sync.set({'remainingopens': Object.fromEntries(options.blacklist.map((key, _index) => [key, options.allowedOpens]))});
+    }
+    
     let unlocked = now - unlockTime <= options.siteTime;
     if (unlocked) {
         if (timeoutId !== null) {
@@ -74,12 +85,10 @@ async function handleTab(tabId, url) {
 }
 
 function lockTab(tabId, blacklist) {
-    chrome.storage.sync.set({'lastunlock': 0}, () => {
-        chrome.tabs.get(tabId, (tab) => {
-            if (tab.active && tab.url && isDiscouraged(tab.url, blacklist)) {
-                chrome.tabs.update(tabId, {url: chrome.runtime.getURL('unlock.html') + '?url=' + encodeURIComponent(tab.url)});
-            }
-        });
+    chrome.tabs.get(tabId, (tab) => {
+        if (tab.active && tab.url && isDiscouraged(tab.url, blacklist)) {
+            chrome.tabs.update(tabId, {url: chrome.runtime.getURL('unlock.html') + '?url=' + encodeURIComponent(tab.url)});
+        }
     });
 }
 

--- a/options.html
+++ b/options.html
@@ -16,6 +16,10 @@
     <input id="sitetime" type="number"></input>
     <br/>
     <br/>
+    Number of allowed opens per day: (-1 to disable)<br/>
+    <input id="allowedopens" type="number"></input>
+    <br/>
+    <br/>
     Schedule by time of day:<br/>
     <input type="checkbox" id="scheduleenabled"></input> <label for="scheduleenabled">enabled</label><br/>
     <input id="schedulefromtime" type="time"></input>

--- a/options.js
+++ b/options.js
@@ -1,11 +1,14 @@
 async function getOptions() {
     return new Promise((resolve) => {
-        chrome.storage.sync.get(['blacklist', 'sitetime', 'frictiontime', 'lastunlock', 'schedule'], (items) => {
+        chrome.storage.sync.get(['blacklist', 'sitetime', 'frictiontime', 'allowedopens', 'remainingopens', 'lastunlock', 'schedule'], (items) => {
             if (!items) {
+                let defaults = ['reddit.com', 'facebook.com', 'twitter.com'];
                 resolve({
-                    blacklist: ['reddit.com', 'facebook.com', 'twitter.com'],
-                    siteTime: 120,
-                    frictionTime: 6
+                    blacklist: defaults,
+                    siteTime: 1,
+                    frictionTime: 6,
+                    allowedOpens: -1,
+                    remainingOpens: Object.fromEntries(defaults.map((key, _index) => [key, 0]))
                 });
                 return;
             }
@@ -15,6 +18,8 @@ async function getOptions() {
             }
             let siteTime = items.sitetime || 120;
             let frictionTime = items.frictiontime || 6;
+            let allowedOpens = items.allowedopens || -1;
+            let remainingOpens = items.remainingopens || Object.fromEntries(blacklist.map((key, _index) => [key, 0]));
             let lastUnlock = items.lastunlock || 0;
             let schedule = items.schedule || null;
 
@@ -22,6 +27,8 @@ async function getOptions() {
                 blacklist: blacklist,
                 siteTime: siteTime,
                 frictionTime: frictionTime,
+                allowedOpens: allowedOpens,
+                remainingOpens: remainingOpens,
                 lastUnlock: lastUnlock,
                 schedule: schedule,
             });

--- a/optionspage.js
+++ b/optionspage.js
@@ -1,4 +1,4 @@
-let blacklistInput, siteTimeInput, frictionTimeInput;
+let blacklistInput, siteTimeInput, frictionTimeInput, allowedOpensInput;
 let scheduleEnabledInput, scheduleFromInput, scheduleToInput;
 let savedTimeout;
 
@@ -16,6 +16,10 @@ async function init() {
     frictionTimeInput.value = options.frictionTime;
     frictionTimeInput.addEventListener('change', () => save());
     frictionTimeInput.addEventListener('blur', () => save());
+    allowedOpensInput = document.getElementById('allowedopens');
+    allowedOpensInput.value = options.allowedOpens;
+    allowedOpensInput.addEventListener('change', () => save());
+    allowedOpensInput.addEventListener('blur', () => save());
     scheduleEnabledInput = document.getElementById('scheduleenabled');
     scheduleEnabledInput.checked = options.schedule != null;
     scheduleEnabledInput.addEventListener('change', () => save());
@@ -32,7 +36,7 @@ async function init() {
     }
 }
 
-function save() {
+async function save() {
     let schedule = null;
     if (scheduleEnabledInput.checked) {
         let from = scheduleFromInput.valueAsNumber;
@@ -47,10 +51,20 @@ function save() {
             {from: from, to: to},
         ];
     }
+    let options = await getOptions();
+    let remainingOpens;
+    if (allowedOpensInput.value !== options.allowedOpens) {
+        remainingOpens = Object.fromEntries(Object.entries(options.remainingOpens).map((item, index) => [item[0], allowedOpensInput.value]));
+    } else {
+        remainingOpens = options.remainingOpens;
+    }
+    
     chrome.storage.sync.set({
         'blacklist': blacklistInput.value,
         'sitetime': siteTimeInput.value,
         'frictiontime': frictionTimeInput.value,
+        'allowedopens': allowedOpensInput.value,
+        'remainingopens': remainingOpens,
         'schedule': schedule
     }, () => showSavedMessage());
 }

--- a/unlock.html
+++ b/unlock.html
@@ -19,6 +19,8 @@
     <br/>
     <span id="countdown"></span><br/>
     <br/>
+    <span id="remaining"></span><br/>
+    <br/>
     <br/>
     <button id="unlockbutton">Unlock</button>
 </body>

--- a/unlockpage.js
+++ b/unlockpage.js
@@ -2,29 +2,55 @@ let countdown;
 let running = true;
 let query;
 let timeout;
+let remainingOpens;
+let host;
 
 async function init() {
     let options = await getOptions();
     countdown = options.frictionTime;
+    remainingOpens = options.remainingOpens;
 
     query = parseQuery(window.location.search);
+    
+    let a = document.createElement('a');
+    a.href = query.url;
+    host = a.hostname.toLowerCase();
+    for (let i=0; i<options.blacklist.length; i++) {
+        let entry = options.blacklist[i].trim();
+        if (entry == "") {
+            continue;
+        }
+        if (entry.length <= host.length && host.indexOf(entry) === host.length - entry.length) {
+            let remaining = host.substring(0, host.length - entry.length);
+            if (remaining.length === 0 || remaining[remaining.length-1] === '.') {
+                host = entry;
+                break;
+            }
+        }
+    }
+    
     document.getElementById('url').innerText = query.url;
     document.getElementById('unlockbutton').addEventListener('click', () => unlock());
     document.getElementById('unlockbutton').disabled = true;
-    document.getElementById('countdown').innerText = '' + countdown;
-    window.addEventListener('blur', () => {
-        countdown = options.frictionTime;
+    if (options.allowedOpens >= 0) {
+        document.getElementById('remaining').innerText = `Used: ${options.allowedOpens - remainingOpens[host]}/${options.allowedOpens}`;
+    }
+    if (remainingOpens[host] > 0 || options.allowedOpens < 0) {
         document.getElementById('countdown').innerText = '' + countdown;
-        document.getElementById('unlockbutton').disabled = true;
-        running = false;
-    });
-    window.addEventListener('focus', () => {
-        running = true;
-        countdown = options.frictionTime;
-        clearTimeout(timeout);
+        window.addEventListener('blur', () => {
+            countdown = options.frictionTime;
+            document.getElementById('countdown').innerText = '' + countdown;
+            document.getElementById('unlockbutton').disabled = true;
+            running = false;
+        });
+        window.addEventListener('focus', () => {
+            running = true;
+            countdown = options.frictionTime;
+            clearTimeout(timeout);
+            timeout = setTimeout(() => doCountdown(), 1000);
+        });
         timeout = setTimeout(() => doCountdown(), 1000);
-    });
-    timeout = setTimeout(() => doCountdown(), 1000);
+    }
 }
 
 async function doCountdown() {
@@ -46,7 +72,8 @@ async function doCountdown() {
 }
 
 function unlock() {
-    chrome.storage.sync.set({'lastunlock': Date.now() / 1000}, () => {
+    remainingOpens[host] -= 1;
+    chrome.storage.sync.set({'lastunlock': Date.now() / 1000, 'remainingopens': remainingOpens}, () => {
         getOptions().then((options) => {
             window.location = query.url;
         });


### PR DESCRIPTION
Adds a new option which defines how many times the user is allowed to unlock a site. After exceeding the limit, the site is blocked untill midnight. The feature is disabled by default by setting the option to -1.

![locked-with-used](https://github.com/tfriedel6/friction/assets/37140289/15df0bc8-635a-415d-969f-cab849d374e3)

Test by setting the option "Number of allowed opens per day" to a number greater than zero and browsing to a blacklisted site.